### PR TITLE
Remove the "I'm not deleting this repo." hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,3 @@ To change FFlags, go to Framework -> Global -> ReplicatedStorage -> OB_Services 
 
 Demo game: https://www.roblox.com/games/7423761766/OB-Framework 
 Module ID: 7467219669
-
-![I'm not deleting this repo.](https://user-images.githubusercontent.com/73150246/154198649-446296de-3195-4f55-87d4-bd75c9eafe37.mp4)


### PR DESCRIPTION
It serves no purpose and leads to ear rape. Has the same purpose as a shock-link, whether intended or not.