### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OPENBLOX has been replaced with ob-framework. This engine can simulate 2016L, 20
 ![2016E](https://media.discordapp.net/attachments/880711006098190338/945120991560994877/RobloxScreenShot20220220_195024339.png)
 2016M:
 ![2016M](https://media.discordapp.net/attachments/880711006098190338/945120992055930910/RobloxScreenShot20220220_195110153.png)
-2016l:
+2016L:
 ![2016L](https://media.discordapp.net/attachments/880711006098190338/945120992525688872/RobloxScreenShot20220220_195133770.png)
 # How do I use this?
 Go to the Examples folder for more information.


### PR DESCRIPTION
Fix typo in README.md. The typo was above the Late 2016 screenshot, and instead of "2016L:", I typed "2016l:".